### PR TITLE
ADD: Description for response to be validate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -193,6 +193,7 @@ function getPaths(data) {
           // apiDoc error group defaults to 'Error 4xx'.
           const statusCode = response.group.replace(/(Success|Error)\ /, '').toUpperCase();
           responseObject = {
+            description: response.group,
             content: {
               [contentType]: {
                 schema: {


### PR DESCRIPTION
Since new validation tool for OpenAI they have an error with the generated file. I use [apitools.dev](https://apitools.dev/swagger-parser/online/) to validate the `openapi.json`

Simply add Description Field to solve issues with the validation with the `openapi.json`